### PR TITLE
remove unneeded imports from conversion script

### DIFF
--- a/examples/eth-addr-format-to-ss58.js
+++ b/examples/eth-addr-format-to-ss58.js
@@ -1,9 +1,4 @@
-const { ethers } = require('ethers');
-const { ApiPromise, WsProvider, Keyring } = require('@polkadot/api');
 const { convertH160ToSS58 } = require('./address-mapping.js');
-
-// PROTECT YOUR PRIVATE KEYS WELL, NEVER COMMIT THEM TO GITHUB OR SHARE WITH ANYONE
-const { ethPrivateKey, subSeed, rpcUrl, wsUrl } = require('./config.js');
 
 async function main() {
   // Paste your Metamask wallet account address (Ethereum H160 address) into recipientEthereumAddress. For example:
@@ -17,4 +12,4 @@ async function main() {
 }
 
 main().catch(console.error);
-console.warn = () => {};
+console.warn = () => { };


### PR DESCRIPTION
We don't need to import the private key from the config for this